### PR TITLE
article_imageにCASCADEを追加

### DIFF
--- a/db/init.d/02-article-cascade.sql
+++ b/db/init.d/02-article-cascade.sql
@@ -1,0 +1,4 @@
+ALTER TABLE article_images
+    DROP CONSTRAINT article_images_article_id_user_id_fkey;
+ALTER TABLE article_images
+    ADD FOREIGN KEY (article_id, user_id) REFERENCES article_detail (article_id, user_id) ON DELETE CASCADE;

--- a/src/Feature/Article/Infrastructure/Persistence/PublishedArticleRepository.php
+++ b/src/Feature/Article/Infrastructure/Persistence/PublishedArticleRepository.php
@@ -125,14 +125,6 @@ class PublishedArticleRepository implements PublishedArticleRepositoryInterface
             'article_id' => $article_id,
             'user_id' => $user_id
         ]);
-
-        $statement = $pdo->prepare('
-            DELETE FROM article_images WHERE article_id = :article_id AND user_id = :user_id
-        ');
-        $statement->execute([
-            'article_id' => $article_id,
-            'user_id' => $user_id
-        ]);
     }
 
     /**


### PR DESCRIPTION
## Overview

- article_imageの外部キー参照をarticleからarticle_detailに向け直してDELETE CASCADEをつける

今ある他のテーブルには要件的に不要と判断してつけていませんが他につけたほうが良さそうな箇所があれば指摘お願いします

現在のテーブル構成
https://github.com/Romira915/training-php-sql/blob/84f24cf14b7b52e29ede04aff532b05fc534e24c/db/init.d/00-article.sql