### PR TITLE
複数画像アップロードに対応

### DIFF
--- a/src/Feature/Article/Application/DTO/CreatePublishedArticleDTO.php
+++ b/src/Feature/Article/Application/DTO/CreatePublishedArticleDTO.php
@@ -11,6 +11,8 @@ readonly class CreatePublishedArticleDTO
         public string $title,
         public string $body,
         public string $thumbnail_image_path,
+        /** @var string[] */
+        public array  $image_path_list,
     )
     {
     }

--- a/src/Feature/Article/Application/UseCases/CreatePublishArticleUseCase.php
+++ b/src/Feature/Article/Application/UseCases/CreatePublishArticleUseCase.php
@@ -26,12 +26,18 @@ class CreatePublishArticleUseCase
         try {
             $image_path = $imageStorage->moveUploadedFile($publishedArticleDTO->thumbnail_image_path);
             $thumbnail = new ArticleImage(user_id: $publishedArticleDTO->user_id, image_path: $image_path);
+            
+            $images = array_map(
+                fn($image_path) => new ArticleImage(user_id: $publishedArticleDTO->user_id, image_path: $imageStorage->moveUploadedFile($image_path)),
+                $publishedArticleDTO->image_path_list
+            );
+
             $article = new PublishedArticle(
                 user_id: $publishedArticleDTO->user_id,
                 title: $publishedArticleDTO->title,
                 body: $publishedArticleDTO->body,
                 thumbnail: $thumbnail,
-                images: []
+                images: $images
             );
 
             $articleRepository::save($pdo, $article);

--- a/src/Feature/Article/Interfaces/Http/PostUsersIdArticlesRequest.php
+++ b/src/Feature/Article/Interfaces/Http/PostUsersIdArticlesRequest.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Romira\Zenita\Feature\Article\Interfaces\Http;
+
+use InvalidArgumentException;
+use Romira\Zenita\Feature\Article\Interfaces\Exception\InvalidArticleParameterException;
+use Romira\Zenita\Feature\Article\Interfaces\Exception\InvalidUploadImageException;
+use Romira\Zenita\Feature\Article\Interfaces\Validator\BodyValidator;
+use Romira\Zenita\Feature\Article\Interfaces\Validator\TitleValidator;
+use Romira\Zenita\Feature\Article\Interfaces\Validator\UploadImageValidator;
+
+readonly class PostUsersIdArticlesRequest
+{
+    private function __construct(
+        public int    $user_id,
+        public string $title,
+        public string $body,
+        /** @var array{
+         *     name: string,
+         *     full_path: string,
+         *     type: string,
+         *     tmp_name: string,
+         *     error: int,
+         *     size: int,
+         *     }
+         */
+        public array  $thumbnail_file,
+        /** @var array{
+         *     array{
+         *         name: string,
+         *         full_path: string,
+         *         type: string,
+         *         tmp_name: string,
+         *         error: int,
+         *         size: int,
+         *     }
+         * }
+         */
+        public array  $image_files,
+    )
+    {
+    }
+
+    public static function new(string $user_id, string $title, string $body, array $thumbnail_file, array $image_files): PostUsersIdArticlesRequest|InvalidArgumentException|InvalidArticleParameterException|InvalidUploadImageException
+    {
+        if (!is_numeric($user_id)) {
+            return new InvalidArgumentException('Invalid user_id');
+        }
+
+        if (!TitleValidator::validate($title) || !BodyValidator::validate($body)) {
+            return new InvalidArticleParameterException('Invalid title or body');
+        }
+
+        if (empty($thumbnail_file)) {
+            return new InvalidUploadImageException('Invalid image');
+        }
+
+        $upload_image_validator = UploadImageValidator::validate($thumbnail_file);
+        if ($upload_image_validator instanceof InvalidUploadImageException) {
+            return $upload_image_validator;
+        }
+
+        foreach ($image_files as $image_file) {
+            $upload_image_validator = UploadImageValidator::validate($image_file);
+            if ($upload_image_validator instanceof InvalidUploadImageException) {
+                return $upload_image_validator;
+            }
+        }
+
+        return new self((int)$user_id, $title, $body, $thumbnail_file, $image_files);
+    }
+}

--- a/src/Feature/Article/Presentation/IndexViewHelper.php
+++ b/src/Feature/Article/Presentation/IndexViewHelper.php
@@ -51,7 +51,7 @@ class IndexViewHelper extends ViewHelper
     private function createArticleFormElement(): string
     {
         return '
-            <form class="flex flex-col gap-4 items-center w-fit" action="/articles" method="post" enctype="multipart/form-data">
+            <form class="flex flex-col gap-4 items-center w-fit" action="/users/1/articles" method="post" enctype="multipart/form-data">
                 <input type="hidden" name="MAX_FILE_SIZE" value="10485760" />
                 <div class="flex flex-col items-start gap-2 justify-between w-full">
                     <label for="title" >タイトル</label>
@@ -64,6 +64,10 @@ class IndexViewHelper extends ViewHelper
                 <div class="flex flex-col items-start gap-2 justify-between w-full">
                     <label for="thumbnail">サムネイル</label>
                     <input type="file" id="thumbnail" name="thumbnail" accept="image/jpeg, image/png, image/gif" class="" required>
+                </div>
+                <div class="flex flex-col items-start gap-2 justify-between w-full">
+                    <label for="images">画像</label>
+                    <input type="file" id="images" name="images[]" accept="image/jpeg, image/png, image/gif" multiple>
                 </div>
                 <button type="submit" class="bg-gray-300 px-4 py-1 rounded hover:bg-gray-400">投稿</button>
             </form>

--- a/src/Main.php
+++ b/src/Main.php
@@ -9,9 +9,9 @@ use Romira\Zenita\Common\Interfaces\Routes\Route;
 use Romira\Zenita\Feature\Article\Interfaces\Handlers\GetIndex;
 use Romira\Zenita\Feature\Article\Interfaces\Handlers\GetUsersIdArticlesId;
 use Romira\Zenita\Feature\Article\Interfaces\Handlers\GetUsersIdArticlesIdEdit;
-use Romira\Zenita\Feature\Article\Interfaces\Handlers\PostArticles;
 use Romira\Zenita\Feature\Article\Interfaces\Handlers\PostUsersIdArticleIdDelete;
 use Romira\Zenita\Feature\Article\Interfaces\Handlers\PostUsersIdArticleIdEdit;
+use Romira\Zenita\Feature\Article\Interfaces\Handlers\PostUsersIdArticles;
 
 
 class Main
@@ -26,7 +26,7 @@ class Main
 
         $route
             ->get('/', new GetIndex())
-            ->post('/articles', new PostArticles())
+            ->post('/users/{user_id}/articles', new PostUsersIdArticles())
             ->get('/users/{user_id}/articles/{article_id}', new GetUsersIdArticlesId())
             ->get('/users/{user_id}/articles/{article_id}/edit', new GetUsersIdArticlesIdEdit())
             ->post('/users/{user_id}/articles/{article_id}/edit', new PostUsersIdArticleIdEdit())

--- a/src/Utils/File.php
+++ b/src/Utils/File.php
@@ -25,4 +25,49 @@ class File
     {
         return unlink($filePath);
     }
+
+    /**
+     * @param array $files
+     * @return array $result
+     *
+     * @example
+     * $files = [
+     *    'name' => ['file1.jpg', 'file2.jpg'],
+     *    'type' => ['image/jpeg', 'image/jpeg'],
+     *    'tmp_name' => ['/tmp/php7hj2d', '/tmp/php7hj2e'],
+     *    'error' => [0, 0],
+     *    'size' => [98174, 98174],
+     * ];
+     *
+     * $result = File::reshapeFilesArray($files);
+     *
+     * output >>
+     * $result = [
+     *  0 => [
+     *      'name' => 'file1.jpg',
+     *      'type' => 'image/jpeg',
+     *      'tmp_name' => '/tmp/php7hj2d',
+     *      'error' => 0,
+     *      'size' => 98174,
+     *  ],
+     *  1 => [
+     *      'name' => 'file2.jpg',
+     *      'type' => 'image/jpeg',
+     *      'tmp_name' => '/tmp/php7hj2e',
+     *      'error' => 0,
+     *      'size' => 98174,
+     *  ],
+     * ];
+     */
+    public static function reshapeFilesArray(array $files): array
+    {
+        $result = [];
+        foreach ($files as $key => $valueArray) {
+            foreach ($valueArray as $index => $value) {
+                $result[$index][$key] = $value;
+            }
+        }
+
+        return $result;
+    }
 }


### PR DESCRIPTION
## OverView

- 複数画像アップロードに対応する
- Repo内の画像の扱いはサムネイル以外を削除してインサートすることで対応する
- endpointを/users/{user_id}/articlesに変更